### PR TITLE
[HPB-169] [FE] 建立 API 呼叫層

### DIFF
--- a/app/composables/useApiClient.ts
+++ b/app/composables/useApiClient.ts
@@ -1,5 +1,6 @@
 import { ApiError } from '@/utils/errors'
 import { useJwtToken } from './useJwtToken'
+import { joinURL } from 'ufo'
 
 /**
  * API Client composable with automatic JWT token injection
@@ -18,7 +19,7 @@ export function useApiClient() {
       query?: Record<string, unknown>
     } = {}
   ): Promise<T> {
-    const url = `${baseURL}${endpoint}`
+    const url = joinURL(baseURL, endpoint)
 
     // Set default headers
     const headers: Record<string, string> = {
@@ -45,8 +46,8 @@ export function useApiClient() {
         statusCode?: number
         data?: { message?: string }
       }
-      const statusCode = errorObj.statusCode || 500
-      const message = errorObj.data?.message || 'An unknown error occurred'
+      const statusCode = errorObj.statusCode ?? 500
+      const message = errorObj.data?.message ?? 'An unknown error occurred'
 
       throw new ApiError(message, statusCode, errorObj.data)
     }

--- a/app/composables/useApiClient.ts
+++ b/app/composables/useApiClient.ts
@@ -1,0 +1,96 @@
+import { ApiError } from '@/utils/errors'
+import { useJwtToken } from './useJwtToken'
+
+/**
+ * API Client composable with automatic JWT token injection
+ * Uses reactive token from useJwtToken for up-to-date authentication
+ */
+export function useApiClient() {
+  const { token } = useJwtToken()
+  const baseURL = '/api'
+
+  // 通用請求方法
+  async function request<T>(
+    endpoint: string,
+    options: {
+      method?: 'GET' | 'POST' | 'PUT' | 'DELETE'
+      body?: unknown
+      query?: Record<string, unknown>
+    } = {}
+  ): Promise<T> {
+    const url = `${baseURL}${endpoint}`
+
+    // 設定預設 headers
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json'
+    }
+
+    // 自動加入 JWT token - 從響應式 ref 讀取最新值
+    if (token.value) {
+      headers.Authorization = `Bearer ${token.value}`
+    }
+
+    try {
+      const response = await $fetch<T>(url, {
+        method: options.method || 'GET',
+        headers,
+        body: options.body as Record<string, unknown> | BodyInit | null | undefined,
+        query: options.query
+      })
+
+      return response
+    } catch (error: unknown) {
+      // 簡化錯誤處理：$fetch 統一錯誤格式
+      const errorObj = error as {
+        statusCode?: number
+        status?: number
+        data?: { message?: string }
+        message?: string
+      }
+      const statusCode = errorObj.statusCode || errorObj.status || 500
+      const message = errorObj.data?.message || errorObj.message || '發生未知錯誤'
+      const responseData = errorObj.data
+
+      throw new ApiError(message, statusCode, responseData)
+    }
+  }
+
+  // GET 請求
+  async function get<T>(endpoint: string, query?: Record<string, unknown>): Promise<T> {
+    return request<T>(endpoint, {
+      method: 'GET',
+      query
+    })
+  }
+
+  // POST 請求
+  async function post<T>(endpoint: string, body?: unknown): Promise<T> {
+    return request<T>(endpoint, {
+      method: 'POST',
+      body
+    })
+  }
+
+  // PUT 請求
+  async function put<T>(endpoint: string, body?: unknown): Promise<T> {
+    return request<T>(endpoint, {
+      method: 'PUT',
+      body
+    })
+  }
+
+  // DELETE 請求
+  async function deleteRequest<T>(endpoint: string): Promise<T> {
+    return request<T>(endpoint, {
+      method: 'DELETE'
+    })
+  }
+
+  return {
+    request,
+    get,
+    post,
+    put,
+    delete: deleteRequest
+  }
+}

--- a/app/composables/useApiClient.ts
+++ b/app/composables/useApiClient.ts
@@ -44,12 +44,13 @@ export function useApiClient() {
       // Transform $fetch error into ApiError based on backend API spec
       const errorObj = error as {
         statusCode?: number
-        data?: { message?: string }
+        data?: { code?: number; message?: string }
       }
       const statusCode = errorObj.statusCode ?? 500
       const message = errorObj.data?.message ?? 'An unknown error occurred'
+      const code = errorObj.data?.code
 
-      throw new ApiError(message, statusCode, errorObj.data)
+      throw new ApiError(message, statusCode, errorObj.data, code)
     }
   }
 

--- a/app/composables/useApiClient.ts
+++ b/app/composables/useApiClient.ts
@@ -9,7 +9,7 @@ export function useApiClient() {
   const { token } = useJwtToken()
   const baseURL = '/api'
 
-  // 通用請求方法
+  // Generic request method
   async function request<T>(
     endpoint: string,
     options: {
@@ -20,12 +20,12 @@ export function useApiClient() {
   ): Promise<T> {
     const url = `${baseURL}${endpoint}`
 
-    // 設定預設 headers
+    // Set default headers
     const headers: Record<string, string> = {
       'Content-Type': 'application/json'
     }
 
-    // 自動加入 JWT token - 從響應式 ref 讀取最新值
+    // Inject JWT token from reactive ref
     if (token.value) {
       headers.Authorization = `Bearer ${token.value}`
     }
@@ -40,22 +40,19 @@ export function useApiClient() {
 
       return response
     } catch (error: unknown) {
-      // 簡化錯誤處理：$fetch 統一錯誤格式
+      // Transform $fetch error into ApiError based on backend API spec
       const errorObj = error as {
         statusCode?: number
-        status?: number
         data?: { message?: string }
-        message?: string
       }
-      const statusCode = errorObj.statusCode || errorObj.status || 500
-      const message = errorObj.data?.message || errorObj.message || '發生未知錯誤'
-      const responseData = errorObj.data
+      const statusCode = errorObj.statusCode || 500
+      const message = errorObj.data?.message || 'An unknown error occurred'
 
-      throw new ApiError(message, statusCode, responseData)
+      throw new ApiError(message, statusCode, errorObj.data)
     }
   }
 
-  // GET 請求
+  // GET request
   async function get<T>(endpoint: string, query?: Record<string, unknown>): Promise<T> {
     return request<T>(endpoint, {
       method: 'GET',
@@ -63,7 +60,7 @@ export function useApiClient() {
     })
   }
 
-  // POST 請求
+  // POST request
   async function post<T>(endpoint: string, body?: unknown): Promise<T> {
     return request<T>(endpoint, {
       method: 'POST',
@@ -71,7 +68,7 @@ export function useApiClient() {
     })
   }
 
-  // PUT 請求
+  // PUT request
   async function put<T>(endpoint: string, body?: unknown): Promise<T> {
     return request<T>(endpoint, {
       method: 'PUT',
@@ -79,7 +76,7 @@ export function useApiClient() {
     })
   }
 
-  // DELETE 請求
+  // DELETE request
   async function deleteRequest<T>(endpoint: string): Promise<T> {
     return request<T>(endpoint, {
       method: 'DELETE'

--- a/app/composables/useJwtToken.ts
+++ b/app/composables/useJwtToken.ts
@@ -1,0 +1,31 @@
+import { useCookie } from '#app'
+
+export const TOKEN_KEY = 'jwt-token' as const
+
+/**
+ * JWT token composable using Nuxt's useCookie
+ * Provides reactive token management with SSR support
+ */
+export function useJwtToken() {
+  const token = useCookie<string | null>(TOKEN_KEY, {
+    maxAge: 60 * 60 * 24 * 7, // 7 days
+    sameSite: 'lax'
+  })
+
+  const get = () => token.value ?? null
+
+  const set = (value: string) => {
+    token.value = value
+  }
+
+  const remove = () => {
+    token.value = null
+  }
+
+  return {
+    token, // expose reactive ref for computed dependencies
+    get,
+    set,
+    remove
+  }
+}

--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -1,0 +1,57 @@
+// API 型別定義，基於 swagger.yml
+
+export interface User {
+  id: number
+  username: string
+  created_at: string
+  updated_at: string
+}
+
+export interface AuthorInfo {
+  id: number
+  username: string
+}
+
+export interface Article {
+  id: number
+  author: AuthorInfo
+  title: string
+  slug: string
+  content: string
+  published_at: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface NewArticle {
+  title: string
+  content: string
+  slug?: string
+  published_at?: string | null
+}
+
+export interface UpdateArticle {
+  title?: string
+  content?: string
+  slug?: string
+  published_at?: string | null
+}
+
+export interface LoginRequest {
+  username: string
+  password: string
+}
+
+export interface LoginResponse {
+  token: string
+  user: User
+}
+
+export interface ApiError {
+  message: string
+}
+
+export interface PaginationParams {
+  page?: number
+  limit?: number
+}

--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -48,8 +48,3 @@ export interface LoginResponse {
 export interface ApiError {
   message: string
 }
-
-export interface PaginationParams {
-  page?: number
-  limit?: number
-}

--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -1,8 +1,5 @@
-export interface User {
-  id: number
+export interface LoginUser {
   username: string
-  created_at: string
-  updated_at: string
 }
 
 export interface AuthorInfo {
@@ -24,7 +21,7 @@ export interface Article {
 export interface NewArticle {
   title: string
   content: string
-  slug?: string
+  slug: string
   published_at?: string | null
 }
 
@@ -42,7 +39,7 @@ export interface LoginRequest {
 
 export interface LoginResponse {
   token: string
-  user: User
+  user: LoginUser
 }
 
 export interface ErrorResponse {

--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -1,5 +1,3 @@
-// API 型別定義，基於 swagger.yml
-
 export interface User {
   id: number
   username: string

--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -45,6 +45,7 @@ export interface LoginResponse {
   user: User
 }
 
-export interface ApiError {
+export interface ErrorResponse {
+  code: number
   message: string
 }

--- a/app/utils/errors.ts
+++ b/app/utils/errors.ts
@@ -2,7 +2,8 @@ export class ApiError extends Error {
   constructor(
     message: string,
     public statusCode: number,
-    public response?: unknown
+    public response?: unknown,
+    public code?: number
   ) {
     super(message)
     this.name = 'ApiError'

--- a/app/utils/errors.ts
+++ b/app/utils/errors.ts
@@ -1,4 +1,3 @@
-// API 錯誤類別
 export class ApiError extends Error {
   constructor(
     message: string,

--- a/app/utils/errors.ts
+++ b/app/utils/errors.ts
@@ -1,0 +1,11 @@
+// API 錯誤類別
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public statusCode: number,
+    public response?: unknown
+  ) {
+    super(message)
+    this.name = 'ApiError'
+  }
+}

--- a/test/nuxt/useApiClient.test.ts
+++ b/test/nuxt/useApiClient.test.ts
@@ -131,7 +131,7 @@ describe('useApiClient', () => {
       } catch (error) {
         expect(error).toBeInstanceOf(ApiError)
         expect((error as ApiError).statusCode).toBe(500)
-        expect((error as ApiError).message).toBe('發生未知錯誤')
+        expect((error as ApiError).message).toBe('An unknown error occurred')
       }
     })
   })

--- a/test/nuxt/useApiClient.test.ts
+++ b/test/nuxt/useApiClient.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, beforeEach, vi, type MockedFunction } from 'vitest'
+import { ApiError } from '@/utils/errors'
+import { useApiClient } from '@/composables/useApiClient'
+import { createMockApiError } from '../unit/api-mock-data'
+
+// Mock $fetch globally
+const mockFetch = vi.fn()
+
+// Mock the global $fetch function that Nuxt auto-imports
+Object.defineProperty(globalThis, '$fetch', {
+  value: mockFetch,
+  writable: true,
+  configurable: true
+})
+
+// Mock useJwtToken
+vi.mock('@/composables/useJwtToken', () => ({
+  useJwtToken: vi.fn()
+}))
+
+describe('useApiClient', () => {
+  let mockFetchFn: MockedFunction<typeof mockFetch>
+  let mockTokenRef: { value: string | null }
+
+  beforeEach(async () => {
+    mockFetchFn = mockFetch as MockedFunction<typeof mockFetch>
+    vi.clearAllMocks()
+
+    // Create a mock token ref
+    mockTokenRef = { value: null }
+
+    // Mock useJwtToken to return our mock token ref
+    const { useJwtToken } = await import('@/composables/useJwtToken')
+    vi.mocked(useJwtToken).mockReturnValue({
+      token: mockTokenRef as ReturnType<typeof useJwtToken>['token'],
+      get: () => mockTokenRef.value,
+      set: (val: string) => {
+        mockTokenRef.value = val
+      },
+      remove: () => {
+        mockTokenRef.value = null
+      }
+    })
+  })
+
+  describe('request method', () => {
+    it('should make a GET request with correct parameters', async () => {
+      const mockResponse = { data: 'test' }
+      mockFetchFn.mockResolvedValue(mockResponse)
+
+      const apiClient = useApiClient()
+      const result = await apiClient.get('/test', { param: 'value' })
+
+      expect(mockFetchFn).toHaveBeenCalledWith('/api/test', {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: undefined,
+        query: { param: 'value' }
+      })
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('should make a POST request with body', async () => {
+      const mockResponse = { success: true }
+      const requestBody = { title: 'Test' }
+      mockFetchFn.mockResolvedValue(mockResponse)
+
+      const apiClient = useApiClient()
+      const result = await apiClient.post('/test', requestBody)
+
+      expect(mockFetchFn).toHaveBeenCalledWith('/api/test', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: requestBody,
+        query: undefined
+      })
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('should include Authorization header when token is available', async () => {
+      const mockResponse = { data: 'test' }
+      mockFetchFn.mockResolvedValue(mockResponse)
+
+      // Set token value
+      mockTokenRef.value = 'test-token'
+
+      const apiClient = useApiClient()
+      await apiClient.get('/test')
+
+      expect(mockFetchFn).toHaveBeenCalledWith('/api/test', {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-token'
+        },
+        body: undefined,
+        query: undefined
+      })
+    })
+
+    it('should handle $fetch errors and throw ApiError', async () => {
+      const mockError = createMockApiError(404, 'Not found')
+      mockFetchFn.mockRejectedValue(mockError)
+
+      const apiClient = useApiClient()
+      await expect(apiClient.get('/test')).rejects.toThrow(ApiError)
+
+      try {
+        await apiClient.get('/test')
+      } catch (error) {
+        expect(error).toBeInstanceOf(ApiError)
+        expect((error as ApiError).statusCode).toBe(404)
+        expect((error as ApiError).message).toBe('Not found')
+        expect((error as ApiError).response).toEqual({ message: 'Not found' })
+      }
+    })
+
+    it('should handle unknown errors with default values', async () => {
+      const mockError = { unknown: 'error' }
+      mockFetchFn.mockRejectedValue(mockError)
+
+      const apiClient = useApiClient()
+      await expect(apiClient.get('/test')).rejects.toThrow(ApiError)
+
+      try {
+        await apiClient.get('/test')
+      } catch (error) {
+        expect(error).toBeInstanceOf(ApiError)
+        expect((error as ApiError).statusCode).toBe(500)
+        expect((error as ApiError).message).toBe('發生未知錯誤')
+      }
+    })
+  })
+
+  describe('HTTP methods', () => {
+    beforeEach(() => {
+      mockFetchFn.mockResolvedValue({ success: true })
+    })
+
+    it('should call GET method correctly', async () => {
+      const mockResponse = { data: 'test' }
+      mockFetchFn.mockResolvedValue(mockResponse)
+
+      const apiClient = useApiClient()
+      const result = await apiClient.get('/test', { param: 'value' })
+
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('should call POST method correctly', async () => {
+      const mockResponse = { success: true }
+      const body = { data: 'test' }
+      mockFetchFn.mockResolvedValue(mockResponse)
+
+      const apiClient = useApiClient()
+      const result = await apiClient.post('/test', body)
+
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('should call PUT method correctly', async () => {
+      const mockResponse = { updated: true }
+      const body = { data: 'updated' }
+      mockFetchFn.mockResolvedValue(mockResponse)
+
+      const apiClient = useApiClient()
+      const result = await apiClient.put('/test', body)
+
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('should call DELETE method correctly', async () => {
+      const mockResponse = { deleted: true }
+      mockFetchFn.mockResolvedValue(mockResponse)
+
+      const apiClient = useApiClient()
+      const result = await apiClient.delete('/test')
+
+      expect(result).toEqual(mockResponse)
+    })
+  })
+
+  describe('reactive token integration', () => {
+    it('should use updated token value in subsequent requests', async () => {
+      mockFetchFn.mockResolvedValue({ success: true })
+
+      const apiClient = useApiClient()
+
+      // First request without token
+      await apiClient.get('/test1')
+      expect(mockFetchFn).toHaveBeenLastCalledWith(
+        '/api/test1',
+        expect.objectContaining({
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        })
+      )
+
+      // Set token
+      mockTokenRef.value = 'new-token'
+
+      // Second request should include token
+      await apiClient.get('/test2')
+      expect(mockFetchFn).toHaveBeenLastCalledWith(
+        '/api/test2',
+        expect.objectContaining({
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer new-token'
+          }
+        })
+      )
+
+      // Remove token
+      mockTokenRef.value = null
+
+      // Third request should not include token
+      await apiClient.get('/test3')
+      expect(mockFetchFn).toHaveBeenLastCalledWith(
+        '/api/test3',
+        expect.objectContaining({
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        })
+      )
+    })
+  })
+})

--- a/test/nuxt/useApiClient.test.ts
+++ b/test/nuxt/useApiClient.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, beforeEach, vi, type MockedFunction } from 'vitest'
 import { ApiError } from '@/utils/errors'
 import { useApiClient } from '@/composables/useApiClient'
-import { createMockApiError } from '../unit/api-mock-data'
+import {
+  createMockApiError,
+  createMockApiErrorWithStatus,
+  createIncompleteError
+} from '../unit/api-mock-data'
 
 // Mock $fetch globally
 const mockFetch = vi.fn()
@@ -102,6 +106,48 @@ describe('useApiClient', () => {
       })
     })
 
+    describe('token edge cases', () => {
+      it('should not include Authorization header when token is empty string', async () => {
+        const mockResponse = { data: 'test' }
+        mockFetchFn.mockResolvedValue(mockResponse)
+
+        // Set token to empty string
+        mockTokenRef.value = ''
+
+        const apiClient = useApiClient()
+        await apiClient.get('/test')
+
+        expect(mockFetchFn).toHaveBeenCalledWith('/api/test', {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: undefined,
+          query: undefined
+        })
+      })
+
+      it('should not include Authorization header when token is undefined', async () => {
+        const mockResponse = { data: 'test' }
+        mockFetchFn.mockResolvedValue(mockResponse)
+
+        // Set token to undefined
+        mockTokenRef.value = undefined as unknown as null
+
+        const apiClient = useApiClient()
+        await apiClient.get('/test')
+
+        expect(mockFetchFn).toHaveBeenCalledWith('/api/test', {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: undefined,
+          query: undefined
+        })
+      })
+    })
+
     it('should handle $fetch errors and throw ApiError', async () => {
       const mockError = createMockApiError(404, 'Not found')
       mockFetchFn.mockRejectedValue(mockError)
@@ -133,6 +179,547 @@ describe('useApiClient', () => {
         expect((error as ApiError).statusCode).toBe(500)
         expect((error as ApiError).message).toBe('An unknown error occurred')
       }
+    })
+
+    describe('HTTP status codes', () => {
+      it('should handle 400 Bad Request errors', async () => {
+        const mockError = createMockApiErrorWithStatus(400, 'Title and content are required.')
+        mockFetchFn.mockRejectedValue(mockError)
+
+        const apiClient = useApiClient()
+
+        try {
+          await apiClient.post('/articles', {})
+        } catch (error) {
+          expect(error).toBeInstanceOf(ApiError)
+          expect((error as ApiError).statusCode).toBe(400)
+          expect((error as ApiError).message).toBe('Title and content are required.')
+          expect((error as ApiError).response).toEqual({
+            message: 'Title and content are required.'
+          })
+        }
+      })
+
+      it('should handle 401 Unauthorized errors', async () => {
+        const mockError = createMockApiErrorWithStatus(401, 'Invalid username or password.')
+        mockFetchFn.mockRejectedValue(mockError)
+
+        const apiClient = useApiClient()
+
+        try {
+          await apiClient.post('/auth/login', { username: 'test', password: 'wrong' })
+        } catch (error) {
+          expect(error).toBeInstanceOf(ApiError)
+          expect((error as ApiError).statusCode).toBe(401)
+          expect((error as ApiError).message).toBe('Invalid username or password.')
+          expect((error as ApiError).response).toEqual({ message: 'Invalid username or password.' })
+        }
+      })
+
+      it('should handle 403 Forbidden errors', async () => {
+        const mockError = createMockApiErrorWithStatus(
+          403,
+          'You are not authorized to create articles.'
+        )
+        mockFetchFn.mockRejectedValue(mockError)
+
+        const apiClient = useApiClient()
+
+        try {
+          await apiClient.post('/articles', { title: 'Test' })
+        } catch (error) {
+          expect(error).toBeInstanceOf(ApiError)
+          expect((error as ApiError).statusCode).toBe(403)
+          expect((error as ApiError).message).toBe('You are not authorized to create articles.')
+          expect((error as ApiError).response).toEqual({
+            message: 'You are not authorized to create articles.'
+          })
+        }
+      })
+
+      it('should handle 409 Conflict errors', async () => {
+        const mockError = createMockApiErrorWithStatus(409, 'A post with this slug already exists.')
+        mockFetchFn.mockRejectedValue(mockError)
+
+        const apiClient = useApiClient()
+
+        try {
+          await apiClient.post('/articles', { title: 'Test', slug: 'existing-slug' })
+        } catch (error) {
+          expect(error).toBeInstanceOf(ApiError)
+          expect((error as ApiError).statusCode).toBe(409)
+          expect((error as ApiError).message).toBe('A post with this slug already exists.')
+          expect((error as ApiError).response).toEqual({
+            message: 'A post with this slug already exists.'
+          })
+        }
+      })
+
+      it('should handle 422 Unprocessable Entity errors', async () => {
+        const mockError = createMockApiErrorWithStatus(
+          422,
+          'Request syntax correct but contains semantic errors.'
+        )
+        mockFetchFn.mockRejectedValue(mockError)
+
+        const apiClient = useApiClient()
+
+        try {
+          await apiClient.post('/articles', { title: 'Test', content: 'Content' })
+        } catch (error) {
+          expect(error).toBeInstanceOf(ApiError)
+          expect((error as ApiError).statusCode).toBe(422)
+          expect((error as ApiError).message).toBe(
+            'Request syntax correct but contains semantic errors.'
+          )
+          expect((error as ApiError).response).toEqual({
+            message: 'Request syntax correct but contains semantic errors.'
+          })
+        }
+      })
+
+      it('should handle 500 Internal Server errors with message', async () => {
+        const mockError = createMockApiErrorWithStatus(
+          500,
+          'Failed to create article due to a server issue.'
+        )
+        mockFetchFn.mockRejectedValue(mockError)
+
+        const apiClient = useApiClient()
+
+        try {
+          await apiClient.post('/articles', { title: 'Test' })
+        } catch (error) {
+          expect(error).toBeInstanceOf(ApiError)
+          expect((error as ApiError).statusCode).toBe(500)
+          expect((error as ApiError).message).toBe(
+            'Failed to create article due to a server issue.'
+          )
+          expect((error as ApiError).response).toEqual({
+            message: 'Failed to create article due to a server issue.'
+          })
+        }
+      })
+    })
+
+    describe('error structure edge cases', () => {
+      it('should default to 500 when statusCode is missing', async () => {
+        const mockError = createIncompleteError({
+          data: { message: 'Error without status code' }
+        })
+        mockFetchFn.mockRejectedValue(mockError)
+
+        const apiClient = useApiClient()
+
+        try {
+          await apiClient.get('/test')
+        } catch (error) {
+          expect(error).toBeInstanceOf(ApiError)
+          expect((error as ApiError).statusCode).toBe(500)
+          expect((error as ApiError).message).toBe('Error without status code')
+          expect((error as ApiError).response).toEqual({ message: 'Error without status code' })
+        }
+      })
+
+      it('should default message when data is missing', async () => {
+        const mockError = createIncompleteError({
+          statusCode: 404
+        })
+        mockFetchFn.mockRejectedValue(mockError)
+
+        const apiClient = useApiClient()
+
+        try {
+          await apiClient.get('/test')
+        } catch (error) {
+          expect(error).toBeInstanceOf(ApiError)
+          expect((error as ApiError).statusCode).toBe(404)
+          expect((error as ApiError).message).toBe('An unknown error occurred')
+          expect((error as ApiError).response).toBeUndefined()
+        }
+      })
+
+      it('should default message when data.message is missing', async () => {
+        const mockError = createIncompleteError({
+          statusCode: 400,
+          data: {}
+        })
+        mockFetchFn.mockRejectedValue(mockError)
+
+        const apiClient = useApiClient()
+
+        try {
+          await apiClient.get('/test')
+        } catch (error) {
+          expect(error).toBeInstanceOf(ApiError)
+          expect((error as ApiError).statusCode).toBe(400)
+          expect((error as ApiError).message).toBe('An unknown error occurred')
+          expect((error as ApiError).response).toEqual({})
+        }
+      })
+
+      it('should preserve empty string message', async () => {
+        const mockError = createIncompleteError({
+          statusCode: 400,
+          data: { message: '' }
+        })
+        mockFetchFn.mockRejectedValue(mockError)
+
+        const apiClient = useApiClient()
+
+        try {
+          await apiClient.get('/test')
+        } catch (error) {
+          expect(error).toBeInstanceOf(ApiError)
+          expect((error as ApiError).statusCode).toBe(400)
+          expect((error as ApiError).message).toBe('')
+          expect((error as ApiError).response).toEqual({ message: '' })
+        }
+      })
+
+      it('should preserve complete error response with extra fields', async () => {
+        const mockError = createIncompleteError({
+          statusCode: 400,
+          data: {
+            message: 'Validation failed',
+            code: 'ERR_VALIDATION',
+            details: [
+              { field: 'email', message: 'Invalid email format' },
+              { field: 'password', message: 'Password too short' }
+            ],
+            timestamp: '2023-01-01T00:00:00Z'
+          }
+        })
+        mockFetchFn.mockRejectedValue(mockError)
+
+        const apiClient = useApiClient()
+
+        try {
+          await apiClient.get('/test')
+        } catch (error) {
+          expect(error).toBeInstanceOf(ApiError)
+          expect((error as ApiError).statusCode).toBe(400)
+          expect((error as ApiError).message).toBe('Validation failed')
+          expect((error as ApiError).response).toEqual({
+            message: 'Validation failed',
+            code: 'ERR_VALIDATION',
+            details: [
+              { field: 'email', message: 'Invalid email format' },
+              { field: 'password', message: 'Password too short' }
+            ],
+            timestamp: '2023-01-01T00:00:00Z'
+          })
+        }
+      })
+    })
+
+    describe('query parameters edge cases', () => {
+      it('should handle empty query object', async () => {
+        const mockResponse = { data: 'test' }
+        mockFetchFn.mockResolvedValue(mockResponse)
+
+        const apiClient = useApiClient()
+        await apiClient.get('/test', {})
+
+        expect(mockFetchFn).toHaveBeenCalledWith('/api/test', {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: undefined,
+          query: {}
+        })
+      })
+
+      it('should handle query with multiple parameters', async () => {
+        const mockResponse = { data: 'test' }
+        mockFetchFn.mockResolvedValue(mockResponse)
+
+        const apiClient = useApiClient()
+        await apiClient.get('/articles', { page: 1, limit: 10, sort: 'desc' })
+
+        expect(mockFetchFn).toHaveBeenCalledWith('/api/articles', {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: undefined,
+          query: { page: 1, limit: 10, sort: 'desc' }
+        })
+      })
+
+      it('should handle query with special characters', async () => {
+        const mockResponse = { data: 'test' }
+        mockFetchFn.mockResolvedValue(mockResponse)
+
+        const apiClient = useApiClient()
+        await apiClient.get('/articles', { search: 'test&foo=bar' })
+
+        expect(mockFetchFn).toHaveBeenCalledWith('/api/articles', {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: undefined,
+          query: { search: 'test&foo=bar' }
+        })
+      })
+
+      it('should handle query with numeric values', async () => {
+        const mockResponse = { data: 'test' }
+        mockFetchFn.mockResolvedValue(mockResponse)
+
+        const apiClient = useApiClient()
+        await apiClient.get('/articles', { page: 1, limit: 10 })
+
+        expect(mockFetchFn).toHaveBeenCalledWith('/api/articles', {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: undefined,
+          query: { page: 1, limit: 10 }
+        })
+      })
+
+      it('should handle query with boolean values', async () => {
+        const mockResponse = { data: 'test' }
+        mockFetchFn.mockResolvedValue(mockResponse)
+
+        const apiClient = useApiClient()
+        await apiClient.get('/articles', { published: true, draft: false })
+
+        expect(mockFetchFn).toHaveBeenCalledWith('/api/articles', {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: undefined,
+          query: { published: true, draft: false }
+        })
+      })
+
+      it('should handle query with null values', async () => {
+        const mockResponse = { data: 'test' }
+        mockFetchFn.mockResolvedValue(mockResponse)
+
+        const apiClient = useApiClient()
+        await apiClient.get('/articles', { filter: null })
+
+        expect(mockFetchFn).toHaveBeenCalledWith('/api/articles', {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: undefined,
+          query: { filter: null }
+        })
+      })
+
+      it('should handle query with undefined values', async () => {
+        const mockResponse = { data: 'test' }
+        mockFetchFn.mockResolvedValue(mockResponse)
+
+        const apiClient = useApiClient()
+        await apiClient.get('/articles', { filter: undefined })
+
+        expect(mockFetchFn).toHaveBeenCalledWith('/api/articles', {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: undefined,
+          query: { filter: undefined }
+        })
+      })
+    })
+
+    describe('body edge cases', () => {
+      it('should handle null body in POST', async () => {
+        const mockResponse = { success: true }
+        mockFetchFn.mockResolvedValue(mockResponse)
+
+        const apiClient = useApiClient()
+        await apiClient.post('/test', null)
+
+        expect(mockFetchFn).toHaveBeenCalledWith('/api/test', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: null,
+          query: undefined
+        })
+      })
+
+      it('should handle undefined body in POST', async () => {
+        const mockResponse = { success: true }
+        mockFetchFn.mockResolvedValue(mockResponse)
+
+        const apiClient = useApiClient()
+        await apiClient.post('/test', undefined)
+
+        expect(mockFetchFn).toHaveBeenCalledWith('/api/test', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: undefined,
+          query: undefined
+        })
+      })
+
+      it('should handle empty object body', async () => {
+        const mockResponse = { success: true }
+        mockFetchFn.mockResolvedValue(mockResponse)
+
+        const apiClient = useApiClient()
+        await apiClient.post('/test', {})
+
+        expect(mockFetchFn).toHaveBeenCalledWith('/api/test', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: {},
+          query: undefined
+        })
+      })
+
+      it('should handle nested object body', async () => {
+        const mockResponse = { success: true }
+        mockFetchFn.mockResolvedValue(mockResponse)
+
+        const nestedBody = {
+          user: {
+            name: 'test',
+            profile: {
+              email: 'test@example.com',
+              age: 25
+            }
+          }
+        }
+
+        const apiClient = useApiClient()
+        await apiClient.post('/test', nestedBody)
+
+        expect(mockFetchFn).toHaveBeenCalledWith('/api/test', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: nestedBody,
+          query: undefined
+        })
+      })
+
+      it('should handle array body', async () => {
+        const mockResponse = { success: true }
+        mockFetchFn.mockResolvedValue(mockResponse)
+
+        const arrayBody = [1, 2, 3, 4, 5]
+
+        const apiClient = useApiClient()
+        await apiClient.post('/test', arrayBody)
+
+        expect(mockFetchFn).toHaveBeenCalledWith('/api/test', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: arrayBody,
+          query: undefined
+        })
+      })
+
+      it('should handle string body', async () => {
+        const mockResponse = { success: true }
+        mockFetchFn.mockResolvedValue(mockResponse)
+
+        const stringBody = 'raw string data'
+
+        const apiClient = useApiClient()
+        await apiClient.post('/test', stringBody)
+
+        expect(mockFetchFn).toHaveBeenCalledWith('/api/test', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: stringBody,
+          query: undefined
+        })
+      })
+    })
+
+    describe('endpoint format variations', () => {
+      it('should handle endpoint without leading slash', async () => {
+        const mockResponse = { data: 'test' }
+        mockFetchFn.mockResolvedValue(mockResponse)
+
+        const apiClient = useApiClient()
+        await apiClient.get('test')
+
+        expect(mockFetchFn).toHaveBeenCalledWith('/api/test', {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: undefined,
+          query: undefined
+        })
+      })
+
+      it('should handle endpoint with multiple path segments', async () => {
+        const mockResponse = { data: 'test' }
+        mockFetchFn.mockResolvedValue(mockResponse)
+
+        const apiClient = useApiClient()
+        await apiClient.get('/articles/my-slug/comments')
+
+        expect(mockFetchFn).toHaveBeenCalledWith('/api/articles/my-slug/comments', {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: undefined,
+          query: undefined
+        })
+      })
+
+      it('should handle root endpoint', async () => {
+        const mockResponse = { data: 'test' }
+        mockFetchFn.mockResolvedValue(mockResponse)
+
+        const apiClient = useApiClient()
+        await apiClient.get('/')
+
+        expect(mockFetchFn).toHaveBeenCalledWith('/api', {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: undefined,
+          query: undefined
+        })
+      })
+
+      it('should handle endpoint with trailing slash', async () => {
+        const mockResponse = { data: 'test' }
+        mockFetchFn.mockResolvedValue(mockResponse)
+
+        const apiClient = useApiClient()
+        await apiClient.get('/test/')
+
+        expect(mockFetchFn).toHaveBeenCalledWith('/api/test/', {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: undefined,
+          query: undefined
+        })
+      })
     })
   })
 
@@ -181,6 +768,44 @@ describe('useApiClient', () => {
       const result = await apiClient.delete('/test')
 
       expect(result).toEqual(mockResponse)
+    })
+
+    describe('method and body combinations', () => {
+      it('should allow POST without body', async () => {
+        const mockResponse = { success: true }
+        mockFetchFn.mockResolvedValue(mockResponse)
+
+        const apiClient = useApiClient()
+        const result = await apiClient.post('/test')
+
+        expect(mockFetchFn).toHaveBeenCalledWith('/api/test', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: undefined,
+          query: undefined
+        })
+        expect(result).toEqual(mockResponse)
+      })
+
+      it('should allow PUT without body', async () => {
+        const mockResponse = { updated: true }
+        mockFetchFn.mockResolvedValue(mockResponse)
+
+        const apiClient = useApiClient()
+        const result = await apiClient.put('/test')
+
+        expect(mockFetchFn).toHaveBeenCalledWith('/api/test', {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: undefined,
+          query: undefined
+        })
+        expect(result).toEqual(mockResponse)
+      })
     })
   })
 

--- a/test/nuxt/useJwtToken.test.ts
+++ b/test/nuxt/useJwtToken.test.ts
@@ -63,4 +63,97 @@ describe('useJwtToken', () => {
     // The exposed token should reflect the change
     expect(token.value).toBe('new-token')
   })
+
+  describe('cookie configuration', () => {
+    it('should call useCookie with correct configuration', async () => {
+      const { useCookie } = await import('#app')
+
+      useJwtToken()
+
+      expect(useCookie).toHaveBeenCalledWith(TOKEN_KEY, {
+        maxAge: 60 * 60 * 24 * 7, // 7 days
+        sameSite: 'lax'
+      })
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle empty string', () => {
+      const { set, get } = useJwtToken()
+
+      set('')
+
+      expect(mockCookieRef.value).toBe('')
+      expect(get()).toBe('')
+    })
+
+    it('should handle real JWT token format', () => {
+      const { set, get } = useJwtToken()
+      const realJwtToken =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
+
+      set(realJwtToken)
+
+      expect(mockCookieRef.value).toBe(realJwtToken)
+      expect(get()).toBe(realJwtToken)
+    })
+
+    it('should handle consecutive set operations (overwriting)', () => {
+      const { set, get } = useJwtToken()
+
+      set('first-token')
+      expect(get()).toBe('first-token')
+
+      set('second-token')
+      expect(get()).toBe('second-token')
+
+      set('third-token')
+      expect(get()).toBe('third-token')
+    })
+
+    it('should handle consecutive remove operations', () => {
+      const { set, remove, get } = useJwtToken()
+
+      set('test-token')
+      remove()
+      expect(get()).toBe(null)
+
+      remove() // Remove again when already null
+      expect(get()).toBe(null)
+    })
+  })
+
+  describe('token lifecycle', () => {
+    it('should handle complete state transitions: null → token → null → another token', () => {
+      const { set, remove, get } = useJwtToken()
+
+      // Initial state: null
+      expect(get()).toBe(null)
+
+      // Set first token
+      set('first-token')
+      expect(get()).toBe('first-token')
+
+      // Remove token (back to null)
+      remove()
+      expect(get()).toBe(null)
+
+      // Set another token
+      set('second-token')
+      expect(get()).toBe('second-token')
+    })
+
+    it('should overwrite existing token correctly', () => {
+      const { set, get } = useJwtToken()
+
+      // Set initial token
+      set('initial-token')
+      expect(get()).toBe('initial-token')
+
+      // Overwrite with new token
+      set('new-token')
+      expect(get()).toBe('new-token')
+      expect(mockCookieRef.value).toBe('new-token')
+    })
+  })
 })

--- a/test/nuxt/useJwtToken.test.ts
+++ b/test/nuxt/useJwtToken.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ref } from 'vue'
+import { useJwtToken, TOKEN_KEY } from '@/composables/useJwtToken'
+
+// Mock useCookie
+vi.mock('#app', () => ({
+  useCookie: vi.fn()
+}))
+
+describe('TOKEN_KEY', () => {
+  it('should have the correct value', () => {
+    expect(TOKEN_KEY).toBe('jwt-token')
+  })
+})
+
+describe('useJwtToken', () => {
+  let mockCookieRef: ReturnType<typeof ref<string | null>>
+
+  beforeEach(async () => {
+    // Create a real Vue ref so computed can track it
+    mockCookieRef = ref<string | null>(null)
+
+    // Mock useCookie to return our mock ref
+    const { useCookie } = await import('#app')
+    vi.mocked(useCookie).mockReturnValue(mockCookieRef as unknown as ReturnType<typeof useCookie>)
+  })
+
+  it('should initialize with null token', () => {
+    const { get } = useJwtToken()
+
+    expect(get()).toBe(null)
+  })
+
+  it('should set token correctly', () => {
+    const { set, get } = useJwtToken()
+
+    set('test-token')
+
+    expect(mockCookieRef.value).toBe('test-token')
+    expect(get()).toBe('test-token')
+  })
+
+  it('should remove token correctly', () => {
+    // Set token first
+    mockCookieRef.value = 'test-token'
+
+    const { remove, get } = useJwtToken()
+
+    remove()
+
+    expect(mockCookieRef.value).toBe(null)
+    expect(get()).toBe(null)
+  })
+
+  it('should expose reactive token ref', () => {
+    const { token } = useJwtToken()
+
+    expect(token.value).toBe(null)
+
+    // Directly modify the mock cookie ref
+    mockCookieRef.value = 'new-token'
+
+    // The exposed token should reflect the change
+    expect(token.value).toBe('new-token')
+  })
+})

--- a/test/unit/api-mock-data.ts
+++ b/test/unit/api-mock-data.ts
@@ -1,0 +1,90 @@
+import type {
+  User,
+  AuthorInfo,
+  Article,
+  NewArticle,
+  UpdateArticle,
+  LoginRequest,
+  LoginResponse,
+  PaginationParams
+} from '@/types/api'
+
+export const createMockUser = (overrides: Partial<User> = {}): User => ({
+  id: 1,
+  username: 'testuser',
+  created_at: '2023-01-01T00:00:00Z',
+  updated_at: '2023-01-01T00:00:00Z',
+  ...overrides
+})
+
+export const createMockAuthorInfo = (overrides: Partial<AuthorInfo> = {}): AuthorInfo => ({
+  id: 1,
+  username: 'author',
+  ...overrides
+})
+
+export const createMockArticle = (overrides: Partial<Article> = {}): Article => ({
+  id: 1,
+  author: createMockAuthorInfo(),
+  title: 'Test Article',
+  slug: 'test-article',
+  content: 'This is test content',
+  published_at: '2023-01-01T00:00:00Z',
+  created_at: '2023-01-01T00:00:00Z',
+  updated_at: '2023-01-01T00:00:00Z',
+  ...overrides
+})
+
+export const createMockNewArticle = (overrides: Partial<NewArticle> = {}): NewArticle => ({
+  title: 'New Test Article',
+  content: 'New test content',
+  slug: 'new-test-article',
+  published_at: '2023-01-01T00:00:00Z',
+  ...overrides
+})
+
+export const createMockUpdateArticle = (overrides: Partial<UpdateArticle> = {}): UpdateArticle => ({
+  title: 'Updated Test Article',
+  content: 'Updated test content',
+  ...overrides
+})
+
+export const createMockLoginRequest = (overrides: Partial<LoginRequest> = {}): LoginRequest => ({
+  username: 'testuser',
+  password: 'testpassword',
+  ...overrides
+})
+
+export const createMockLoginResponse = (overrides: Partial<LoginResponse> = {}): LoginResponse => ({
+  token: 'mock-jwt-token',
+  user: createMockUser(),
+  ...overrides
+})
+
+export const createMockPaginationParams = (
+  overrides: Partial<PaginationParams> = {}
+): PaginationParams => ({
+  page: 1,
+  limit: 10,
+  ...overrides
+})
+
+export const createMockApiError = (
+  statusCode: number = 500,
+  message: string = 'Internal Server Error'
+) => ({
+  statusCode,
+  status: statusCode,
+  data: { message },
+  message
+})
+
+export const createMockArticlesList = (count: number = 3): Article[] => {
+  return Array.from({ length: count }, (_, index) =>
+    createMockArticle({
+      id: index + 1,
+      title: `Test Article ${index + 1}`,
+      slug: `test-article-${index + 1}`
+    })
+  )
+}

--- a/test/unit/api-mock-data.ts
+++ b/test/unit/api-mock-data.ts
@@ -1,5 +1,5 @@
 import type {
-  User,
+  LoginUser,
   AuthorInfo,
   Article,
   NewArticle,
@@ -8,11 +8,8 @@ import type {
   LoginResponse
 } from '@/types/api'
 
-export const createMockUser = (overrides: Partial<User> = {}): User => ({
-  id: 1,
+export const createMockUser = (overrides: Partial<LoginUser> = {}): LoginUser => ({
   username: 'testuser',
-  created_at: '2023-01-01T00:00:00Z',
-  updated_at: '2023-01-01T00:00:00Z',
   ...overrides
 })
 

--- a/test/unit/api-mock-data.ts
+++ b/test/unit/api-mock-data.ts
@@ -66,7 +66,7 @@ export const createMockApiError = (
 ) => ({
   statusCode,
   status: statusCode,
-  data: { message },
+  data: { code: statusCode, message },
   message
 })
 
@@ -95,7 +95,7 @@ export const createMockApiErrorWithStatus = (
  */
 export const createIncompleteError = (parts: {
   statusCode?: number
-  data?: { message?: string; [key: string]: unknown } | null
+  data?: { code?: number; message?: string; [key: string]: unknown } | null
 }) => parts
 
 export const createMockArticlesList = (count: number = 3): Article[] => {

--- a/test/unit/api-mock-data.ts
+++ b/test/unit/api-mock-data.ts
@@ -79,6 +79,34 @@ export const createMockApiError = (
   message
 })
 
+/**
+ * Create mock API error with predefined messages for common status codes
+ */
+export const createMockApiErrorWithStatus = (
+  statusCode: 400 | 401 | 403 | 404 | 409 | 422 | 500,
+  message?: string
+) => {
+  const defaultMessages: Record<number, string> = {
+    400: 'Bad Request',
+    401: 'Unauthorized',
+    403: 'Forbidden',
+    404: 'Not Found',
+    409: 'Conflict',
+    422: 'Unprocessable Entity',
+    500: 'Internal Server Error'
+  }
+
+  return createMockApiError(statusCode, message || defaultMessages[statusCode])
+}
+
+/**
+ * Create incomplete error structure for edge case testing
+ */
+export const createIncompleteError = (parts: {
+  statusCode?: number
+  data?: { message?: string; [key: string]: unknown } | null
+}) => parts
+
 export const createMockArticlesList = (count: number = 3): Article[] => {
   return Array.from({ length: count }, (_, index) =>
     createMockArticle({

--- a/test/unit/api-mock-data.ts
+++ b/test/unit/api-mock-data.ts
@@ -5,8 +5,7 @@ import type {
   NewArticle,
   UpdateArticle,
   LoginRequest,
-  LoginResponse,
-  PaginationParams
+  LoginResponse
 } from '@/types/api'
 
 export const createMockUser = (overrides: Partial<User> = {}): User => ({
@@ -58,14 +57,6 @@ export const createMockLoginRequest = (overrides: Partial<LoginRequest> = {}): L
 export const createMockLoginResponse = (overrides: Partial<LoginResponse> = {}): LoginResponse => ({
   token: 'mock-jwt-token',
   user: createMockUser(),
-  ...overrides
-})
-
-export const createMockPaginationParams = (
-  overrides: Partial<PaginationParams> = {}
-): PaginationParams => ({
-  page: 1,
-  limit: 10,
   ...overrides
 })
 


### PR DESCRIPTION
[Issue Link](https://www.notion.so/FE-API-279cba948f118077a69ac3b1e0f959b0?source=copy_link)

## Summary

這個 PR 專注於一個處理 API request / response 的 API client，旨在標準化與後端的通訊。提供一組 composables (`useApiClient` 和 `useJwtToken`)，用於處理請求生命週期、自動 JWT 驗證和結構化錯誤處理。

## Major changes

- **`app/composables/useApiClient.ts`**: 此功能的核心。它是一個封裝了 `$fetch` 的 composable，並提供：
  - `GET`, `POST`, `PUT`, `DELETE` 請求的方法。
  - 響應式監聽 `useJwtToken`，自動注入 `Authorization: Bearer <token>` header。
  - 集中的錯誤處理，可捕獲 fetch 錯誤並將其轉換為自定義的、結構化的 `ApiError`。

- **`app/composables/useJwtToken.ts`**: 一個專門用於管理使用者 JWT 的 composable。它使用 `useCookie` 來實現持久化和 SSR 相容性，並提供簡單的 `get`、`set` 和 `remove` 方法。

- **`app/utils/errors.ts`**: 定義了 `ApiError` 類別，它擴展了原生的 `Error`，以包含 `statusCode` 和原始回應資料，使 UI 可以進行更精確的錯誤處理。

- **`app/types/api.ts`**: 包含所有後端資料模型的 TypeScript 介面（例如 `Article`、`User`、`LoginResponse`）

- **`test/**`**: 為新的 composables 新增了全面的單元測試

## How to test

執行完整的 CI pipeline：
```bash
make ci
```
結果應無警告或錯誤。

## Testing

`test/unit/api-mock-data.ts`
- Mock 資料工廠函數
- 可重複使用的測試工具

`test/nuxt/useJwtToken.test.ts`
- Token 初始化、設定與移除
- 響應式 token ref 行為
- 與 Nuxt 的 Cookie 整合

`test/nuxt/useApiClient.test.ts`
- 所有 HTTP 方法 (GET, POST, PUT, DELETE)
- Query 參數處理（空值、多個、特殊字元、null/undefined、布林值）
- 請求 body 變化（null、undefined、空物件、巢狀物件、陣列、字串）
- Endpoint 格式變化（有/無前導斜線、多段路徑、尾隨斜線）
- Token 邊界情況（空字串、undefined、null）
- HTTP 狀態碼（400、401、403、404、409、422、500）
- 錯誤結構邊界情況（缺少 statusCode、缺少 message、額外欄位）
- 響應式 token 在多個請求間的整合
