### PR TITLE
[HPB-161] [FE] 建立 CRUD API 層

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,13 +16,13 @@ This is a Nuxt.js 4 frontend application for the HPB Blog project. It's configur
 
 ### Code Quality
 
-- `make ci` - Run complete CI pipeline (format, test, and lint in parallel)
-- `make lint` - Run ESLint and TypeScript type checking
-- `make format` - Fix ESLint issues and format code with Prettier
+- `make ci-llm` - Run complete CI pipeline (format, test, and lint in parallel)
+- `make lint-llm` - Run ESLint and TypeScript type checking
+- `make fmt-llm` - Fix ESLint issues and format code with Prettier
 
 ### Testing
 
-- `make test` - Run Vitest tests
+- `make test-llm` - Run Vitest tests
 - Test files are located in `test/unit/`, `test/e2e/`, and `test/nuxt/` directories
 
 ## Architecture
@@ -64,7 +64,7 @@ This is a Nuxt.js 4 frontend application for the HPB Blog project. It's configur
 
 After writing code, run the CI pipeline to ensure code quality:
 
-- `make ci` - Run complete CI pipeline (format code, then run tests and linting in parallel)
+- `make ci-llm` - Run complete CI pipeline (format code, then run tests and linting in parallel)
 
 This command will automatically format your code and run both tests and type checking concurrently. All checks must pass before committing code.
 

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,10 @@ format:
 	@npx prettier --write . >/dev/null 2>&1 || true
 
 lint:
-	@npx eslint . --quiet
-	@npx nuxt typecheck --logLevel=silent
+	@(npx eslint . --quiet) & (npx nuxt typecheck --logLevel=silent) & wait
 
 lint-verbose:
-	@npx eslint .
-	@npx nuxt typecheck
+	@(npx eslint .) & (npx nuxt typecheck) & wait
 
 test:
 	@npx vitest run --reporter=dot --silent
@@ -19,5 +17,5 @@ ci:
 	@echo "Running format..."
 	@$(MAKE) format || true
 	@echo "Running tests and lint in parallel..."
-	@($(MAKE) test || true) & ($(MAKE) lint-verbose || true) & wait
+	@$(MAKE) test & $(MAKE) lint-verbose & wait
 	@echo "CI pipeline completed."

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,38 @@
-.PHONY: format lint lint-verbose test ci
+SHELL := /bin/bash
 
-format:
+.PHONY: fmt fmt-llm lint lint-llm test test-llm ci ci-llm
+
+fmt:
+	@npx eslint . --fix || true
+	@npx prettier --write . || true
+
+fmt-llm:
 	@npx eslint . --fix >/dev/null 2>&1 || true
 	@npx prettier --write . >/dev/null 2>&1 || true
 
 lint:
-	@(npx eslint . --quiet) & (npx nuxt typecheck --logLevel=silent) & wait
-
-lint-verbose:
 	@(npx eslint .) & (npx nuxt typecheck) & wait
 
+lint-llm:
+	@set -o pipefail; \
+	(npx eslint . 2>&1 | grep -v -E '^\[nuxt\]|\[info\]|^ℹ|\[nitro\]') & \
+	(npx nuxt typecheck 2>&1 | grep -v -E '^\[nuxt\]|\[info\]|^ℹ|\[nitro\]|.*\[.*ms\]|.*↳|@tailwindcss') & \
+	wait
+
 test:
-	@npx vitest run --reporter=dot --silent
+	@npx vitest run 
+
+test-llm:
+	@set -o pipefail; npx vitest run --reporter=dot 2>&1 | \
+		grep -v -E '^\[nuxt\]|\[info\]|^ℹ|\[nitro\]|.*\[.*ms\]|.*↳|\(node:.*\) Warning:|Use.*--trace-warnings|^·+$$|@tailwindcss'
 
 ci:
 	@echo "Running format..."
-	@$(MAKE) format || true
+	@$(MAKE) fmt
 	@echo "Running tests and lint in parallel..."
-	@$(MAKE) test & $(MAKE) lint-verbose & wait
+	@$(MAKE) test & $(MAKE) lint & wait
 	@echo "CI pipeline completed."
+
+ci-llm:
+	@$(MAKE) fmt-llm
+	@$(MAKE) test-llm & $(MAKE) lint-llm & wait

--- a/app/composables/useArticle.ts
+++ b/app/composables/useArticle.ts
@@ -1,0 +1,118 @@
+import { ref } from 'vue'
+import type { Article, NewArticle, UpdateArticle } from '@/types/api'
+import { useApiClient } from './useApiClient'
+
+export function useArticle() {
+  const articles = ref<Article[]>([])
+  const currentArticle = ref<Article | null>(null)
+  const loading = ref(false)
+  const error = ref<Error | null>(null)
+
+  // Get API client with automatic token injection
+  const apiClient = useApiClient()
+
+  async function list(params?: Record<string, unknown>) {
+    loading.value = true
+    error.value = null
+
+    try {
+      const result = await apiClient.get<Article[]>('/articles', params)
+      articles.value = result
+      return result
+    } catch (e) {
+      error.value = e as Error
+      throw e
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function get(slug: string) {
+    loading.value = true
+    error.value = null
+
+    try {
+      const result = await apiClient.get<Article>(`/articles/${slug}`)
+      currentArticle.value = result
+      return result
+    } catch (e) {
+      error.value = e as Error
+      throw e
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function create(article: NewArticle) {
+    loading.value = true
+    error.value = null
+
+    try {
+      const result = await apiClient.post<Article>('/articles', article)
+      // 自動更新文章列表
+      articles.value = [result, ...articles.value]
+      return result
+    } catch (e) {
+      error.value = e as Error
+      throw e
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function update(slug: string, article: UpdateArticle) {
+    loading.value = true
+    error.value = null
+
+    try {
+      const result = await apiClient.put<Article>(`/articles/${slug}`, article)
+      // 更新列表中的文章
+      const index = articles.value.findIndex((a) => a.slug === slug)
+      if (index !== -1) {
+        articles.value[index] = result
+      }
+      // 更新當前文章
+      if (currentArticle.value?.slug === slug) {
+        currentArticle.value = result
+      }
+      return result
+    } catch (e) {
+      error.value = e as Error
+      throw e
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function remove(slug: string) {
+    loading.value = true
+    error.value = null
+
+    try {
+      await apiClient.delete(`/articles/${slug}`)
+      // 從列表中移除
+      articles.value = articles.value.filter((a) => a.slug !== slug)
+      // 清除當前文章
+      if (currentArticle.value?.slug === slug) {
+        currentArticle.value = null
+      }
+    } catch (e) {
+      error.value = e as Error
+      throw e
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    articles,
+    currentArticle,
+    loading,
+    error,
+    list,
+    get,
+    create,
+    update,
+    remove
+  }
+}

--- a/app/composables/useArticle.ts
+++ b/app/composables/useArticle.ts
@@ -43,12 +43,12 @@ export function useArticle() {
     }
   }
 
-  async function create(article: NewArticle) {
+  async function create(newArticle: NewArticle) {
     loading.value = true
     error.value = null
 
     try {
-      const result = await apiClient.post<Article>('/articles', article)
+      const result = await apiClient.post<Article>('/articles', newArticle)
       // Automatically update articles list
       articles.value = [result, ...articles.value]
       return result
@@ -60,12 +60,12 @@ export function useArticle() {
     }
   }
 
-  async function update(slug: string, article: UpdateArticle) {
+  async function update(slug: string, updatedArticle: UpdateArticle) {
     loading.value = true
     error.value = null
 
     try {
-      const result = await apiClient.put<Article>(`/articles/${slug}`, article)
+      const result = await apiClient.put<Article>(`/articles/${slug}`, updatedArticle)
       // Update article in list
       const index = articles.value.findIndex((a) => a.slug === slug)
       if (index !== -1) {

--- a/app/composables/useArticle.ts
+++ b/app/composables/useArticle.ts
@@ -49,7 +49,7 @@ export function useArticle() {
 
     try {
       const result = await apiClient.post<Article>('/articles', article)
-      // 自動更新文章列表
+      // Automatically update articles list
       articles.value = [result, ...articles.value]
       return result
     } catch (e) {
@@ -66,12 +66,12 @@ export function useArticle() {
 
     try {
       const result = await apiClient.put<Article>(`/articles/${slug}`, article)
-      // 更新列表中的文章
+      // Update article in list
       const index = articles.value.findIndex((a) => a.slug === slug)
       if (index !== -1) {
         articles.value[index] = result
       }
-      // 更新當前文章
+      // Update current article
       if (currentArticle.value?.slug === slug) {
         currentArticle.value = result
       }
@@ -90,9 +90,9 @@ export function useArticle() {
 
     try {
       await apiClient.delete(`/articles/${slug}`)
-      // 從列表中移除
+      // Remove from list
       articles.value = articles.value.filter((a) => a.slug !== slug)
-      // 清除當前文章
+      // Clear current article
       if (currentArticle.value?.slug === slug) {
         currentArticle.value = null
       }

--- a/app/composables/useArticle.ts
+++ b/app/composables/useArticle.ts
@@ -11,12 +11,12 @@ export function useArticle() {
   // Get API client with automatic token injection
   const apiClient = useApiClient()
 
-  async function list(params?: Record<string, unknown>) {
+  async function list() {
     loading.value = true
     error.value = null
 
     try {
-      const result = await apiClient.get<Article[]>('/articles', params)
+      const result = await apiClient.get<Article[]>('/articles')
       articles.value = result
       return result
     } catch (e) {

--- a/app/composables/useArticle.ts
+++ b/app/composables/useArticle.ts
@@ -1,12 +1,12 @@
-import { ref } from 'vue'
+import { useState } from '#app'
 import type { Article, NewArticle, UpdateArticle } from '@/types/api'
 import { useApiClient } from './useApiClient'
 
 export function useArticle() {
-  const articles = ref<Article[]>([])
-  const currentArticle = ref<Article | null>(null)
-  const loading = ref(false)
-  const error = ref<Error | null>(null)
+  const articles = useState<Article[]>('articles', () => [])
+  const currentArticle = useState<Article | null>('currentArticle', () => null)
+  const loading = useState<boolean>('articles:loading', () => false)
+  const error = useState<Error | null>('articles:error', () => null)
 
   // Get API client with automatic token injection
   const apiClient = useApiClient()

--- a/test/nuxt/useArticle.test.ts
+++ b/test/nuxt/useArticle.test.ts
@@ -96,6 +96,38 @@ describe('useArticle', () => {
       expect(result).toEqual(mockArticle)
     })
 
+    it('should set loading to true during get and false after completion', async () => {
+      const mockArticle = createMockArticle()
+      const slug = 'test-article'
+
+      mockApiClient.get.mockResolvedValue(mockArticle)
+
+      const { get, loading } = useArticle()
+
+      expect(loading.value).toBe(false)
+
+      const promise = get(slug)
+      expect(loading.value).toBe(true)
+
+      await promise
+      expect(loading.value).toBe(false)
+    })
+
+    it('should set loading to false even on error', async () => {
+      const mockError = createMockApiError(404, 'Not found')
+      const slug = 'non-existent'
+
+      mockApiClient.get.mockRejectedValue(mockError)
+
+      const { get, loading } = useArticle()
+
+      expect(loading.value).toBe(false)
+
+      await expect(get(slug)).rejects.toEqual(mockError)
+
+      expect(loading.value).toBe(false)
+    })
+
     it('should handle get errors', async () => {
       const mockError = createMockApiError(404, 'Not found')
       const slug = 'non-existent'
@@ -129,6 +161,38 @@ describe('useArticle', () => {
       expect(result).toEqual(mockCreatedArticle)
     })
 
+    it('should set loading to true during create and false after completion', async () => {
+      const mockNewArticle = createMockNewArticle()
+      const mockCreatedArticle = createMockArticle()
+
+      mockApiClient.post.mockResolvedValue(mockCreatedArticle)
+
+      const { create, loading } = useArticle()
+
+      expect(loading.value).toBe(false)
+
+      const promise = create(mockNewArticle)
+      expect(loading.value).toBe(true)
+
+      await promise
+      expect(loading.value).toBe(false)
+    })
+
+    it('should set loading to false even on error', async () => {
+      const mockError = createMockApiError(400, 'Bad request')
+      const mockNewArticle = createMockNewArticle()
+
+      mockApiClient.post.mockRejectedValue(mockError)
+
+      const { create, loading } = useArticle()
+
+      expect(loading.value).toBe(false)
+
+      await expect(create(mockNewArticle)).rejects.toEqual(mockError)
+
+      expect(loading.value).toBe(false)
+    })
+
     it('should prepend new article to existing list', async () => {
       const existingArticles = createMockArticlesList(2)
       const mockNewArticle = createMockNewArticle()
@@ -145,6 +209,22 @@ describe('useArticle', () => {
 
       expect(articles.value[0]).toEqual(mockCreatedArticle)
       expect(articles.value.length).toBe(3)
+    })
+
+    it('should not update articles list on create failure', async () => {
+      const existingArticles = createMockArticlesList(2)
+      const mockNewArticle = createMockNewArticle()
+      const mockError = createMockApiError(400, 'Bad request')
+
+      mockApiClient.post.mockRejectedValue(mockError)
+
+      const { create, articles } = useArticle()
+      articles.value = [...existingArticles]
+
+      await expect(create(mockNewArticle)).rejects.toEqual(mockError)
+
+      expect(articles.value).toEqual(existingArticles)
+      expect(articles.value.length).toBe(2)
     })
 
     it('should handle create errors', async () => {
@@ -178,6 +258,40 @@ describe('useArticle', () => {
       expect(result).toEqual(mockUpdatedArticle)
     })
 
+    it('should set loading to true during update and false after completion', async () => {
+      const slug = 'test-article'
+      const mockUpdateData = createMockUpdateArticle()
+      const mockUpdatedArticle = createMockArticle({ slug })
+
+      mockApiClient.put.mockResolvedValue(mockUpdatedArticle)
+
+      const { update, loading } = useArticle()
+
+      expect(loading.value).toBe(false)
+
+      const promise = update(slug, mockUpdateData)
+      expect(loading.value).toBe(true)
+
+      await promise
+      expect(loading.value).toBe(false)
+    })
+
+    it('should set loading to false even on error', async () => {
+      const mockError = createMockApiError(404, 'Not found')
+      const slug = 'non-existent'
+      const mockUpdateData = createMockUpdateArticle()
+
+      mockApiClient.put.mockRejectedValue(mockError)
+
+      const { update, loading } = useArticle()
+
+      expect(loading.value).toBe(false)
+
+      await expect(update(slug, mockUpdateData)).rejects.toEqual(mockError)
+
+      expect(loading.value).toBe(false)
+    })
+
     it('should update article in list', async () => {
       const slug = 'test-article'
       const existingArticles = createMockArticlesList(3)
@@ -196,6 +310,25 @@ describe('useArticle', () => {
       expect(articles.value[1]?.title).toBe('New Title')
     })
 
+    it('should not update articles list on update failure', async () => {
+      const slug = 'test-article'
+      const existingArticles = createMockArticlesList(3)
+      existingArticles[1] = createMockArticle({ slug, title: 'Old Title' })
+
+      const mockUpdateData = createMockUpdateArticle({ title: 'New Title' })
+      const mockError = createMockApiError(404, 'Not found')
+
+      mockApiClient.put.mockRejectedValue(mockError)
+
+      const { update, articles } = useArticle()
+      articles.value = [...existingArticles]
+
+      await expect(update(slug, mockUpdateData)).rejects.toEqual(mockError)
+
+      expect(articles.value[1]?.title).toBe('Old Title')
+      expect(articles.value.length).toBe(3)
+    })
+
     it('should update currentArticle if slugs match', async () => {
       const slug = 'test-article'
       const mockUpdateData = createMockUpdateArticle()
@@ -209,6 +342,24 @@ describe('useArticle', () => {
       await update(slug, mockUpdateData)
 
       expect(currentArticle.value).toEqual(mockUpdatedArticle)
+    })
+
+    it('should not update article in list if slug not found', async () => {
+      const slug = 'non-existent'
+      const existingArticles = createMockArticlesList(2)
+      const mockUpdateData = createMockUpdateArticle()
+      const mockUpdatedArticle = createMockArticle({ slug })
+
+      mockApiClient.put.mockResolvedValue(mockUpdatedArticle)
+
+      const { update, articles } = useArticle()
+      articles.value = [...existingArticles]
+
+      await update(slug, mockUpdateData)
+
+      // List should remain unchanged
+      expect(articles.value).toEqual(existingArticles)
+      expect(articles.value.length).toBe(2)
     })
 
     it('should handle update errors', async () => {
@@ -240,6 +391,37 @@ describe('useArticle', () => {
       expect(error.value).toBe(null)
     })
 
+    it('should set loading to true during remove and false after completion', async () => {
+      const slug = 'test-article'
+
+      mockApiClient.delete.mockResolvedValue(undefined)
+
+      const { remove, loading } = useArticle()
+
+      expect(loading.value).toBe(false)
+
+      const promise = remove(slug)
+      expect(loading.value).toBe(true)
+
+      await promise
+      expect(loading.value).toBe(false)
+    })
+
+    it('should set loading to false even on error', async () => {
+      const mockError = createMockApiError(404, 'Not found')
+      const slug = 'non-existent'
+
+      mockApiClient.delete.mockRejectedValue(mockError)
+
+      const { remove, loading } = useArticle()
+
+      expect(loading.value).toBe(false)
+
+      await expect(remove(slug)).rejects.toEqual(mockError)
+
+      expect(loading.value).toBe(false)
+    })
+
     it('should remove article from list', async () => {
       const slug = 'test-article'
       const existingArticles = createMockArticlesList(3)
@@ -269,6 +451,20 @@ describe('useArticle', () => {
       expect(currentArticle.value).toBe(null)
     })
 
+    it('should not clear currentArticle if slugs do not match', async () => {
+      const slug = 'test-article'
+      const differentArticle = createMockArticle({ slug: 'different-article' })
+
+      mockApiClient.delete.mockResolvedValue(undefined)
+
+      const { remove, currentArticle } = useArticle()
+      currentArticle.value = differentArticle
+
+      await remove(slug)
+
+      expect(currentArticle.value).toEqual(differentArticle)
+    })
+
     it('should handle delete errors', async () => {
       const mockError = createMockApiError(404, 'Not found')
       const slug = 'non-existent'
@@ -279,6 +475,185 @@ describe('useArticle', () => {
 
       await expect(remove(slug)).rejects.toEqual(mockError)
       expect(error.value).toEqual(mockError)
+    })
+  })
+
+  describe('error clearing', () => {
+    it('should clear previous error on successful list', async () => {
+      const mockArticles = createMockArticlesList(2)
+      const mockError = createMockApiError(500, 'Server error')
+
+      mockApiClient.get.mockRejectedValueOnce(mockError).mockResolvedValueOnce(mockArticles)
+
+      const { list, error } = useArticle()
+
+      // First call fails
+      await expect(list()).rejects.toEqual(mockError)
+      expect(error.value).toEqual(mockError)
+
+      // Second call succeeds and clears error
+      await list()
+      expect(error.value).toBe(null)
+    })
+
+    it('should clear previous error on successful get', async () => {
+      const mockArticle = createMockArticle()
+      const mockError = createMockApiError(404, 'Not found')
+
+      mockApiClient.get.mockRejectedValueOnce(mockError).mockResolvedValueOnce(mockArticle)
+
+      const { get, error } = useArticle()
+
+      // First call fails
+      await expect(get('non-existent')).rejects.toEqual(mockError)
+      expect(error.value).toEqual(mockError)
+
+      // Second call succeeds and clears error
+      await get('test-article')
+      expect(error.value).toBe(null)
+    })
+
+    it('should clear previous error on successful create', async () => {
+      const mockNewArticle = createMockNewArticle()
+      const mockCreatedArticle = createMockArticle()
+      const mockError = createMockApiError(400, 'Bad request')
+
+      mockApiClient.post.mockRejectedValueOnce(mockError).mockResolvedValueOnce(mockCreatedArticle)
+
+      const { create, error } = useArticle()
+
+      // First call fails
+      await expect(create(mockNewArticle)).rejects.toEqual(mockError)
+      expect(error.value).toEqual(mockError)
+
+      // Second call succeeds and clears error
+      await create(mockNewArticle)
+      expect(error.value).toBe(null)
+    })
+
+    it('should clear previous error on successful update', async () => {
+      const mockUpdateData = createMockUpdateArticle()
+      const mockUpdatedArticle = createMockArticle()
+      const mockError = createMockApiError(404, 'Not found')
+
+      mockApiClient.put.mockRejectedValueOnce(mockError).mockResolvedValueOnce(mockUpdatedArticle)
+
+      const { update, error } = useArticle()
+
+      // First call fails
+      await expect(update('non-existent', mockUpdateData)).rejects.toEqual(mockError)
+      expect(error.value).toEqual(mockError)
+
+      // Second call succeeds and clears error
+      await update('test-article', mockUpdateData)
+      expect(error.value).toBe(null)
+    })
+
+    it('should clear previous error on successful remove', async () => {
+      const mockError = createMockApiError(404, 'Not found')
+
+      mockApiClient.delete.mockRejectedValueOnce(mockError).mockResolvedValueOnce(undefined)
+
+      const { remove, error } = useArticle()
+
+      // First call fails
+      await expect(remove('non-existent')).rejects.toEqual(mockError)
+      expect(error.value).toEqual(mockError)
+
+      // Second call succeeds and clears error
+      await remove('test-article')
+      expect(error.value).toBe(null)
+    })
+  })
+
+  describe('concurrent operations', () => {
+    it('should handle concurrent list calls', async () => {
+      const mockArticles1 = createMockArticlesList(2)
+      const mockArticles2 = createMockArticlesList(3)
+
+      mockApiClient.get.mockResolvedValueOnce(mockArticles1).mockResolvedValueOnce(mockArticles2)
+
+      const { list, articles } = useArticle()
+
+      const [result1, result2] = await Promise.all([list(), list()])
+
+      // Last resolved call should win
+      expect(articles.value).toEqual(mockArticles2)
+      expect(result1).toEqual(mockArticles1)
+      expect(result2).toEqual(mockArticles2)
+    })
+
+    it('should handle concurrent get calls for different slugs', async () => {
+      const mockArticle1 = createMockArticle({ slug: 'article-1' })
+      const mockArticle2 = createMockArticle({ slug: 'article-2' })
+
+      mockApiClient.get.mockImplementation((url: string) => {
+        if (url.includes('article-1')) return Promise.resolve(mockArticle1)
+        if (url.includes('article-2')) return Promise.resolve(mockArticle2)
+        return Promise.reject(new Error('Not found'))
+      })
+
+      const { get, currentArticle } = useArticle()
+
+      const [result1, result2] = await Promise.all([get('article-1'), get('article-2')])
+
+      // Last resolved call should win
+      expect(currentArticle.value).toEqual(mockArticle2)
+      expect(result1).toEqual(mockArticle1)
+      expect(result2).toEqual(mockArticle2)
+    })
+  })
+
+  describe('empty list operations', () => {
+    it('should handle update when articles list is empty', async () => {
+      const slug = 'test-article'
+      const mockUpdateData = createMockUpdateArticle()
+      const mockUpdatedArticle = createMockArticle({ slug })
+
+      mockApiClient.put.mockResolvedValue(mockUpdatedArticle)
+
+      const { update, articles } = useArticle()
+
+      // articles.value is [] by default
+      expect(articles.value).toEqual([])
+
+      await update(slug, mockUpdateData)
+
+      // List should remain empty since article wasn't in it
+      expect(articles.value).toEqual([])
+    })
+
+    it('should handle remove when articles list is empty', async () => {
+      const slug = 'test-article'
+
+      mockApiClient.delete.mockResolvedValue(undefined)
+
+      const { remove, articles } = useArticle()
+
+      // articles.value is [] by default
+      expect(articles.value).toEqual([])
+
+      await remove(slug)
+
+      // List should remain empty
+      expect(articles.value).toEqual([])
+    })
+
+    it('should add to empty list on create', async () => {
+      const mockNewArticle = createMockNewArticle()
+      const mockCreatedArticle = createMockArticle()
+
+      mockApiClient.post.mockResolvedValue(mockCreatedArticle)
+
+      const { create, articles } = useArticle()
+
+      // articles.value is [] by default
+      expect(articles.value).toEqual([])
+
+      await create(mockNewArticle)
+
+      // New article should be added to empty list
+      expect(articles.value).toEqual([mockCreatedArticle])
     })
   })
 })

--- a/test/nuxt/useArticle.test.ts
+++ b/test/nuxt/useArticle.test.ts
@@ -42,9 +42,8 @@ describe('useArticle', () => {
   })
 
   describe('list', () => {
-    it('should fetch articles with query params', async () => {
+    it('should fetch all articles', async () => {
       const mockArticles = createMockArticlesList(3)
-      const mockParams = { page: 1, limit: 10 }
 
       mockApiClient.get.mockResolvedValue(mockArticles)
 
@@ -52,29 +51,16 @@ describe('useArticle', () => {
 
       expect(loading.value).toBe(false)
 
-      const promise = list(mockParams)
+      const promise = list()
       expect(loading.value).toBe(true)
 
       const result = await promise
 
-      expect(mockApiClient.get).toHaveBeenCalledWith('/articles', mockParams)
+      expect(mockApiClient.get).toHaveBeenCalledWith('/articles')
       expect(articles.value).toEqual(mockArticles)
       expect(loading.value).toBe(false)
       expect(error.value).toBe(null)
       expect(result).toEqual(mockArticles)
-    })
-
-    it('should fetch articles without query params', async () => {
-      const mockArticles = createMockArticlesList(5)
-
-      mockApiClient.get.mockResolvedValue(mockArticles)
-
-      const { list, articles } = useArticle()
-
-      await list()
-
-      expect(mockApiClient.get).toHaveBeenCalledWith('/articles', undefined)
-      expect(articles.value).toEqual(mockArticles)
     })
 
     it('should handle list errors', async () => {

--- a/test/nuxt/useArticle.test.ts
+++ b/test/nuxt/useArticle.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useArticle } from '@/composables/useArticle'
+import {
+  createMockArticle,
+  createMockArticlesList,
+  createMockNewArticle,
+  createMockUpdateArticle,
+  createMockApiError
+} from '../unit/api-mock-data'
+
+// Mock useApiClient
+vi.mock('@/composables/useApiClient', () => ({
+  useApiClient: vi.fn()
+}))
+
+describe('useArticle', () => {
+  let mockApiClient: {
+    request: ReturnType<typeof vi.fn>
+    get: ReturnType<typeof vi.fn>
+    post: ReturnType<typeof vi.fn>
+    put: ReturnType<typeof vi.fn>
+    delete: ReturnType<typeof vi.fn>
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+
+    // Mock API client methods
+    mockApiClient = {
+      request: vi.fn(),
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      delete: vi.fn()
+    }
+
+    // Setup mock
+    const { useApiClient } = await import('@/composables/useApiClient')
+    vi.mocked(useApiClient).mockReturnValue(
+      mockApiClient as unknown as ReturnType<typeof useApiClient>
+    )
+  })
+
+  describe('list', () => {
+    it('should fetch articles with query params', async () => {
+      const mockArticles = createMockArticlesList(3)
+      const mockParams = { page: 1, limit: 10 }
+
+      mockApiClient.get.mockResolvedValue(mockArticles)
+
+      const { list, articles, loading, error } = useArticle()
+
+      expect(loading.value).toBe(false)
+
+      const promise = list(mockParams)
+      expect(loading.value).toBe(true)
+
+      const result = await promise
+
+      expect(mockApiClient.get).toHaveBeenCalledWith('/articles', mockParams)
+      expect(articles.value).toEqual(mockArticles)
+      expect(loading.value).toBe(false)
+      expect(error.value).toBe(null)
+      expect(result).toEqual(mockArticles)
+    })
+
+    it('should fetch articles without query params', async () => {
+      const mockArticles = createMockArticlesList(5)
+
+      mockApiClient.get.mockResolvedValue(mockArticles)
+
+      const { list, articles } = useArticle()
+
+      await list()
+
+      expect(mockApiClient.get).toHaveBeenCalledWith('/articles', undefined)
+      expect(articles.value).toEqual(mockArticles)
+    })
+
+    it('should handle list errors', async () => {
+      const mockError = createMockApiError(500, 'Server error')
+
+      mockApiClient.get.mockRejectedValue(mockError)
+
+      const { list, articles, loading, error } = useArticle()
+
+      await expect(list()).rejects.toEqual(mockError)
+
+      expect(articles.value).toEqual([])
+      expect(loading.value).toBe(false)
+      expect(error.value).toEqual(mockError)
+    })
+  })
+
+  describe('get', () => {
+    it('should fetch article by slug', async () => {
+      const mockArticle = createMockArticle()
+      const slug = 'test-article'
+
+      mockApiClient.get.mockResolvedValue(mockArticle)
+
+      const { get, currentArticle, loading, error } = useArticle()
+
+      const result = await get(slug)
+
+      expect(mockApiClient.get).toHaveBeenCalledWith('/articles/test-article')
+      expect(currentArticle.value).toEqual(mockArticle)
+      expect(loading.value).toBe(false)
+      expect(error.value).toBe(null)
+      expect(result).toEqual(mockArticle)
+    })
+
+    it('should handle get errors', async () => {
+      const mockError = createMockApiError(404, 'Not found')
+      const slug = 'non-existent'
+
+      mockApiClient.get.mockRejectedValue(mockError)
+
+      const { get, currentArticle, error } = useArticle()
+
+      await expect(get(slug)).rejects.toEqual(mockError)
+
+      expect(currentArticle.value).toBe(null)
+      expect(error.value).toEqual(mockError)
+    })
+  })
+
+  describe('create', () => {
+    it('should create new article', async () => {
+      const mockNewArticle = createMockNewArticle()
+      const mockCreatedArticle = createMockArticle()
+
+      mockApiClient.post.mockResolvedValue(mockCreatedArticle)
+
+      const { create, articles, loading, error } = useArticle()
+
+      const result = await create(mockNewArticle)
+
+      expect(mockApiClient.post).toHaveBeenCalledWith('/articles', mockNewArticle)
+      expect(articles.value[0]).toEqual(mockCreatedArticle)
+      expect(loading.value).toBe(false)
+      expect(error.value).toBe(null)
+      expect(result).toEqual(mockCreatedArticle)
+    })
+
+    it('should prepend new article to existing list', async () => {
+      const existingArticles = createMockArticlesList(2)
+      const mockNewArticle = createMockNewArticle()
+      const mockCreatedArticle = createMockArticle({ id: 999 })
+
+      mockApiClient.post.mockResolvedValue(mockCreatedArticle)
+
+      const { create, articles } = useArticle()
+
+      // Set existing articles
+      articles.value = existingArticles
+
+      await create(mockNewArticle)
+
+      expect(articles.value[0]).toEqual(mockCreatedArticle)
+      expect(articles.value.length).toBe(3)
+    })
+
+    it('should handle create errors', async () => {
+      const mockError = createMockApiError(400, 'Bad request')
+      const mockNewArticle = createMockNewArticle()
+
+      mockApiClient.post.mockRejectedValue(mockError)
+
+      const { create, error } = useArticle()
+
+      await expect(create(mockNewArticle)).rejects.toEqual(mockError)
+      expect(error.value).toEqual(mockError)
+    })
+  })
+
+  describe('update', () => {
+    it('should update article', async () => {
+      const slug = 'test-article'
+      const mockUpdateData = createMockUpdateArticle()
+      const mockUpdatedArticle = createMockArticle({ slug })
+
+      mockApiClient.put.mockResolvedValue(mockUpdatedArticle)
+
+      const { update, loading, error } = useArticle()
+
+      const result = await update(slug, mockUpdateData)
+
+      expect(mockApiClient.put).toHaveBeenCalledWith(`/articles/${slug}`, mockUpdateData)
+      expect(loading.value).toBe(false)
+      expect(error.value).toBe(null)
+      expect(result).toEqual(mockUpdatedArticle)
+    })
+
+    it('should update article in list', async () => {
+      const slug = 'test-article'
+      const existingArticles = createMockArticlesList(3)
+      existingArticles[1] = createMockArticle({ slug, title: 'Old Title' })
+
+      const mockUpdateData = createMockUpdateArticle({ title: 'New Title' })
+      const mockUpdatedArticle = createMockArticle({ slug, title: 'New Title' })
+
+      mockApiClient.put.mockResolvedValue(mockUpdatedArticle)
+
+      const { update, articles } = useArticle()
+      articles.value = existingArticles
+
+      await update(slug, mockUpdateData)
+
+      expect(articles.value[1]?.title).toBe('New Title')
+    })
+
+    it('should update currentArticle if slugs match', async () => {
+      const slug = 'test-article'
+      const mockUpdateData = createMockUpdateArticle()
+      const mockUpdatedArticle = createMockArticle({ slug })
+
+      mockApiClient.put.mockResolvedValue(mockUpdatedArticle)
+
+      const { update, currentArticle } = useArticle()
+      currentArticle.value = createMockArticle({ slug, title: 'Old Title' })
+
+      await update(slug, mockUpdateData)
+
+      expect(currentArticle.value).toEqual(mockUpdatedArticle)
+    })
+
+    it('should handle update errors', async () => {
+      const mockError = createMockApiError(404, 'Not found')
+      const slug = 'non-existent'
+      const mockUpdateData = createMockUpdateArticle()
+
+      mockApiClient.put.mockRejectedValue(mockError)
+
+      const { update, error } = useArticle()
+
+      await expect(update(slug, mockUpdateData)).rejects.toEqual(mockError)
+      expect(error.value).toEqual(mockError)
+    })
+  })
+
+  describe('remove', () => {
+    it('should delete article', async () => {
+      const slug = 'test-article'
+
+      mockApiClient.delete.mockResolvedValue(undefined)
+
+      const { remove, loading, error } = useArticle()
+
+      await remove(slug)
+
+      expect(mockApiClient.delete).toHaveBeenCalledWith(`/articles/${slug}`)
+      expect(loading.value).toBe(false)
+      expect(error.value).toBe(null)
+    })
+
+    it('should remove article from list', async () => {
+      const slug = 'test-article'
+      const existingArticles = createMockArticlesList(3)
+      existingArticles[1] = createMockArticle({ slug })
+
+      mockApiClient.delete.mockResolvedValue(undefined)
+
+      const { remove, articles } = useArticle()
+      articles.value = existingArticles
+
+      await remove(slug)
+
+      expect(articles.value.length).toBe(2)
+      expect(articles.value.find((a) => a.slug === slug)).toBeUndefined()
+    })
+
+    it('should clear currentArticle if slugs match', async () => {
+      const slug = 'test-article'
+
+      mockApiClient.delete.mockResolvedValue(undefined)
+
+      const { remove, currentArticle } = useArticle()
+      currentArticle.value = createMockArticle({ slug })
+
+      await remove(slug)
+
+      expect(currentArticle.value).toBe(null)
+    })
+
+    it('should handle delete errors', async () => {
+      const mockError = createMockApiError(404, 'Not found')
+      const slug = 'non-existent'
+
+      mockApiClient.delete.mockRejectedValue(mockError)
+
+      const { remove, error } = useArticle()
+
+      await expect(remove(slug)).rejects.toEqual(mockError)
+      expect(error.value).toEqual(mockError)
+    })
+  })
+})

--- a/test/nuxt/useArticle.test.ts
+++ b/test/nuxt/useArticle.test.ts
@@ -39,6 +39,13 @@ describe('useArticle', () => {
     vi.mocked(useApiClient).mockReturnValue(
       mockApiClient as unknown as ReturnType<typeof useApiClient>
     )
+
+    // Reset useState state
+    const { articles, currentArticle, loading, error } = useArticle()
+    articles.value = []
+    currentArticle.value = null
+    loading.value = false
+    error.value = null
   })
 
   describe('list', () => {


### PR DESCRIPTION
[Issue Link](https://www.notion.so/jyu1999/FE-CRUD-API-278cba948f11809587e5de79ebfd1470?source=copy_link)

## Summary

新增 `useArticle` composable 統一管理文章相關的 API 操作，封裝對文章的 CRUD 邏輯，並提供了單元測試確保其穩定性與正確性。

## Major changes

- **`app/composables/useArticle.ts`**:
  - 建立了一個新的 composable `useArticle` 來處理所有與文章相關的資料互動。
  - 提供了 `list`, `get`, `create`, `update`, `remove` 等非同步函式，分別對應文章列表、單一文章查詢、新增、更新與刪除操作。
  - 整合了 `useApiClient`，能自動處理 API request 所需的認證 token。
  - 內部管理了 `articles` 列表、`currentArticle`（當前文章）、`loading`（載入狀態）和 `error`（錯誤狀態）等響應式狀態（reactive state），簡化了在 Vue component 中的使用。

- **`test/nuxt/useArticle.test.ts`**:
  - 為新的 `useArticle` composable 撰寫了完整的 `vitest` 單元測試。
  - 透過模擬 (mock) `useApiClient` 的方式來隔離測試，確保測試的重點在於 `useArticle` 本身的商業邏輯，而非外部 API client。
  - 測試案例涵蓋了所有函式的成功情境、錯誤處理、載入狀態的變化，以及在列表更新、併發請求等各種邊界情況下的行為。

## How to test

請執行以下指令，並確認所有測試案例皆通過，且沒有任何錯誤或警告訊息。

```bash
make ci
```
